### PR TITLE
Add preprocessor guard for compiling without libmoonshot

### DIFF
--- a/mech_eap/util_cred.c
+++ b/mech_eap/util_cred.c
@@ -902,7 +902,9 @@ int peerValidateServerCert(int ok_so_far, X509* cert, void *ca_ctx)
     int                   cert_len;
     unsigned char         hash[32];
     int                   hash_len;
+#ifdef HAVE_MOONSHOT_GET_IDENTITY
     MoonshotError        *error = NULL;
+#endif
     struct eap_peer_config *eap_config = (struct eap_peer_config *) ca_ctx;
     char *identity = strdup((const char *) eap_config->identity);
 


### PR DESCRIPTION
`util_cred.c` does not compile without libmoonshot. Fix this.